### PR TITLE
Get rollup to convert the modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-bind-selectors",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A Redux store enhancer for computing derived state by binding selectors to the store",
   "main": "cjs/bind-selectors.js",
   "module": "es/bind-selectors.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,7 +29,7 @@ export default [
     },
     plugins: [
       // Only need to convert the object rest spread operator since that's not part of ES2015
-      // Rollup with convert the ES2015 modules to CommonJS
+      // Rollup will convert the ES2015 modules to CommonJS
       babel({
         plugins: ['transform-object-rest-spread'],
         babelrc: false
@@ -45,7 +45,7 @@ export default [
     },
     plugins: [
       // Only need to convert the object rest spread operator since that's not part of ES2015
-      // Rollup with convert the ES2015 modules to UMD
+      // Rollup will convert the ES2015 modules to UMD
       babel({
         plugins: ['transform-object-rest-spread'],
         babelrc: false

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,8 +28,12 @@ export default [
       format: 'cjs'
     },
     plugins: [
-      // We assume a modern Node.js version, so only need to convert ES2015 modules and the object rest spread operator.
-      babel() // Uses .babelrc
+      // Only need to convert the object rest spread operator since that's not part of ES2015
+      // Rollup with convert the ES2015 modules to CommonJS
+      babel({
+        plugins: ['transform-object-rest-spread'],
+        babelrc: false
+      })
     ]
   },
   {
@@ -40,8 +44,12 @@ export default [
       format: 'umd'
     },
     plugins: [
-      // We assume a modern browser, only only need to convert ES2015 modules and the object rest spread operator.
-      babel() // Uses .babelrc
+      // Only need to convert the object rest spread operator since that's not part of ES2015
+      // Rollup with convert the ES2015 modules to UMD
+      babel({
+        plugins: ['transform-object-rest-spread'],
+        babelrc: false
+      })
     ]
   }
 ]


### PR DESCRIPTION
Babel module conversion adds an additional `default`, so:
```javascript
const bindSelectors = require('redux-bind-selectors').default
```
which is vile!

Solution: get rollup to do the conversion instead, so we get:
```javascript
const bindSelectors = require('redux-bind-selectors')
```