### PR TITLE
Improved packaging

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "plugins": ["transform-es2015-modules-commonjs", "transform-object-rest-spread"]
+  "presets": ["env"],
+  "plugins": ["transform-object-rest-spread"]
 }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   },
   "homepage": "https://github.com/blgm/redux-bind-selectors#readme",
   "devDependencies": {
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-preset-env": "^1.6.0",
     "jest": "^20.0.4",
     "markdown-link-check": "^3.1.1",
     "redux": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,10 @@
     "redux": "^3.7.2",
     "rollup": "^0.48.2",
     "rollup-plugin-babel": "^3.0.2",
+    "rollup-plugin-uglify": "^2.0.1",
     "standard": "^10.0.3",
-    "standard-markdown": "^4.0.2"
+    "standard-markdown": "^4.0.2",
+    "uglify-es": "^3.0.28"
   },
   "jest": {
     "collectCoverage": true,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,13 +12,11 @@ export default [
       file: 'es/bind-selectors.js',
       format: 'es'
     },
-    plugins: [
-      // Only need to convert the object rest spread operator since that's not part of ES2015
-      babel({
-        plugins: ['transform-object-rest-spread'],
-        babelrc: false
-      })
-    ]
+    plugins: [babel({
+      presets: [['env', {modules: false}]],
+      plugins: ['transform-object-rest-spread'],
+      babelrc: false
+    })]
   },
   {
     input: 'src/bind-selectors.js',
@@ -27,15 +25,11 @@ export default [
       file: 'cjs/bind-selectors.js',
       format: 'cjs'
     },
-    plugins: [
-      // Only need to convert the object rest spread operator since that's not part of ES2015
-      // Rollup will convert the ES2015 modules to CommonJS
-      babel({
-        plugins: ['transform-object-rest-spread'],
-        babelrc: false
-      })
-    ]
-  },
+    plugins: [babel({
+      presets: [['env', {modules: false}]],
+      plugins: ['transform-object-rest-spread'],
+      babelrc: false
+    })] },
   {
     input: 'src/bind-selectors.js',
     name: 'bindSelectors',
@@ -43,13 +37,10 @@ export default [
       file: 'umd/bind-selectors.js',
       format: 'umd'
     },
-    plugins: [
-      // Only need to convert the object rest spread operator since that's not part of ES2015
-      // Rollup will convert the ES2015 modules to UMD
-      babel({
-        plugins: ['transform-object-rest-spread'],
-        babelrc: false
-      })
-    ]
+    plugins: [babel({
+      presets: [['env', {modules: false}]],
+      plugins: ['transform-object-rest-spread'],
+      babelrc: false
+    })]
   }
 ]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,17 @@
  */
 
 import babel from 'rollup-plugin-babel'
+import uglify from 'rollup-plugin-uglify'
+import {minify} from 'uglify-es'
+
+const plugins = () => [
+  babel({
+    presets: [['env', {modules: false}]],
+    plugins: ['transform-object-rest-spread'],
+    babelrc: false
+  }),
+  uglify({}, minify)
+]
 
 export default [
   {
@@ -12,11 +23,7 @@ export default [
       file: 'es/bind-selectors.js',
       format: 'es'
     },
-    plugins: [babel({
-      presets: [['env', {modules: false}]],
-      plugins: ['transform-object-rest-spread'],
-      babelrc: false
-    })]
+    plugins: plugins()
   },
   {
     input: 'src/bind-selectors.js',
@@ -25,11 +32,8 @@ export default [
       file: 'cjs/bind-selectors.js',
       format: 'cjs'
     },
-    plugins: [babel({
-      presets: [['env', {modules: false}]],
-      plugins: ['transform-object-rest-spread'],
-      babelrc: false
-    })] },
+    plugins: plugins()
+  },
   {
     input: 'src/bind-selectors.js',
     name: 'bindSelectors',
@@ -37,10 +41,6 @@ export default [
       file: 'umd/bind-selectors.js',
       format: 'umd'
     },
-    plugins: [babel({
-      presets: [['env', {modules: false}]],
-      plugins: ['transform-object-rest-spread'],
-      babelrc: false
-    })]
+    plugins: plugins()
   }
 ]


### PR DESCRIPTION
- The code in this repo uses ES2015+
  - though we did remove the non-standard object rest spread operator before packaging
- Up to now, this means that consumers (by which I mean myself) have had to run this through Babel
  - however, in general you don't have to run modules from npm through Babel (for example, Redux)

Therefore, in this PR we improve the packaging by:
- shipping ES5 code that does not need to be transformed by Babel
- minimising the code