### PR TITLE
Produce sourcemaps

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,6 @@
 !package.json
 !README.md
 !LICENSE.md
-!cjs/*.js
-!es/*.js
-!umd/*.js
+!cjs/*
+!es/*
+!umd/*

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,40 +7,37 @@ import babel from 'rollup-plugin-babel'
 import uglify from 'rollup-plugin-uglify'
 import {minify} from 'uglify-es'
 
-const plugins = () => [
-  babel({
-    presets: [['env', {modules: false}]],
-    plugins: ['transform-object-rest-spread'],
-    babelrc: false
-  }),
-  uglify({}, minify)
-]
-
-export default [
-  {
-    input: 'src/bind-selectors.js',
-    output: {
+export default {
+  input: 'src/bind-selectors.js',
+  name: 'bindSelectors',
+  sourcemap: true,
+  output: [
+    {
       file: 'es/bind-selectors.js',
       format: 'es'
     },
-    plugins: plugins()
-  },
-  {
-    input: 'src/bind-selectors.js',
-    name: 'bindSelectors',
-    output: {
+    {
       file: 'cjs/bind-selectors.js',
       format: 'cjs'
     },
-    plugins: plugins()
-  },
-  {
-    input: 'src/bind-selectors.js',
-    name: 'bindSelectors',
-    output: {
+    {
       file: 'umd/bind-selectors.js',
       format: 'umd'
-    },
-    plugins: plugins()
-  }
-]
+    }
+  ],
+  plugins: [
+    babel({
+      presets: [['env', {modules: false}]],
+      plugins: ['transform-object-rest-spread'],
+      babelrc: false
+    }),
+    uglify(
+      {
+        output: { // Preserve license
+          comments: (node, {type, value}) => type === 'comment2' && value.includes('license')
+        }
+      },
+      minify
+    )
+  ]
+}


### PR DESCRIPTION
- change uglify to retain the license
- significantly simplify the rollup config
- tell rollup to produce sourcemaps