### PR TITLE
Update rollup again

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "jest": "^20.0.4",
     "markdown-link-check": "^3.1.1",
     "redux": "^3.7.2",
-    "rollup": "^0.49.0",
+    "rollup": "^0.49.1",
     "rollup-plugin-babel": "^3.0.2",
     "rollup-plugin-uglify": "^2.0.1",
     "standard": "^10.0.3",


### PR DESCRIPTION
- rollup 0.49.0 had a major regression
- make sure we can only take 0.49.1 and later