### PR TITLE
Don't minify

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,8 @@
     "redux": "^3.7.2",
     "rollup": "^0.49.1",
     "rollup-plugin-babel": "^3.0.2",
-    "rollup-plugin-uglify": "^2.0.1",
     "standard": "^10.0.3",
-    "standard-markdown": "^4.0.2",
-    "uglify-es": "^3.0.28"
+    "standard-markdown": "^4.0.2"
   },
   "jest": {
     "collectCoverage": true,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,8 +4,6 @@
  */
 
 import babel from 'rollup-plugin-babel'
-import uglify from 'rollup-plugin-uglify'
-import {minify} from 'uglify-es'
 
 export default {
   input: 'src/bind-selectors.js',
@@ -30,14 +28,6 @@ export default {
       presets: [['env', {modules: false}]],
       plugins: ['transform-object-rest-spread'],
       babelrc: false
-    }),
-    uglify(
-      {
-        output: { // Preserve license
-          comments: (node, {type, value}) => type === 'comment2' && value.includes('license')
-        }
-      },
-      minify
-    )
+    })
   ]
 }


### PR DESCRIPTION
On reflection, I decided to back out the minification introduced in #10 because minified code is harder to debug, and we were not giving consumers an option to a version that was not minified.  Best practice is probably to produce:

1. A non-minified CommonJS version
2. A non-minified ES2015 module version
3. A non-minified UMD
4. A minified UMD

We are producing 1, 2 and 3; and not 4.  This would be easy to add in the future, but I don't want to add it now as it's solving a problem that we don't currently have.  The non-minified version is still very small.