### PR TITLE
A few checks for error scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ If the output of `getState()` is used for other purposes (for instance, to persi
 ## Notes
 - A selector cannot have the same path in the state object as a reducer. (This is why we do not simply reuse the `createStructuredSelector()` function from reselect)
 - Paths are all top level object keys
+- A selector cannot return `undefined`, in order to be consistent with Redux where a combined reducer cannot return `undefined`.  Instead, use `null`.
 
 ## License
 See [LICENSE.md](LICENSE.md)

--- a/src/bind-selectors.js
+++ b/src/bind-selectors.js
@@ -22,6 +22,9 @@ export default function bindSelectors (selectorMap = {}) {
       if (key in lastStoreState) {
         throw new Error(`The selector key '${key}' cannot be used because it exists in the initial state`)
       }
+      if (typeof selectorMap[key] !== 'function') {
+        throw new Error(`The selector '${key}' must be a function`)
+      }
     }
 
     const getState = () => {
@@ -32,6 +35,9 @@ export default function bindSelectors (selectorMap = {}) {
         let derivedState = {}
         for (const key in selectorMap) {
           derivedState[key] = selectorMap[key](currentStoreState)
+          if (typeof derivedState[key] === 'undefined') {
+            throw new Error(`Selector '${key}' returned 'undefined'; to indicate no value, return 'null' instead`)
+          }
         }
 
         computedState = {...currentStoreState, ...derivedState}

--- a/src/bind-selectors.spec.js
+++ b/src/bind-selectors.spec.js
@@ -28,12 +28,20 @@ describe('Redux Bind Selectors', () => {
   })
 
   describe('binding selectors', () => {
-    it('fails if a selector key has the same name as a key in the initial state', () => {
+    it('throws if a selector key has the same name as a key in the initial state', () => {
       expect(() => {
         createStore(mockReducer, bindSelectors({
           foo: () => 42 // Same key in the initial state!!
         }))
       }).toThrowError("The selector key 'foo' cannot be used because it exists in the initial state")
+    })
+
+    it('throws if a selector is not a function', () => {
+      expect(() => {
+        createStore(mockReducer, bindSelectors({
+          baz: 42 // Not a function!!
+        }))
+      }).toThrowError("The selector 'baz' must be a function")
     })
 
     it('calls a selector with the state, and assigns its value to the derived state', () => {
@@ -85,6 +93,16 @@ describe('Redux Bind Selectors', () => {
 
       expect(mockSelector).toHaveBeenCalledTimes(1)
       expect(mockSelector).toHaveBeenCalledWith({foo: 'bar'})
+    })
+
+    it('throws when a selector returns `undefined`', () => {
+      const mockSelector = jest.fn().mockReturnValue(undefined)
+      const store = createStore(mockReducer, bindSelectors({
+        fake: mockSelector
+      }))
+
+      expect(() => store.getState())
+        .toThrowError("Selector 'fake' returned 'undefined'; to indicate no value, return 'null' instead")
     })
   })
 


### PR DESCRIPTION
- Check selectors are actually functions
- Check that selectors do not return `undefined`
  - for consistency with Redux where combined reducers cannot return `undefined`
  - because `undefined` is not a JSON value, so does not survive a `JSON.parse(JSON.stringify(..))` loop, which could lead to strange error scenarios